### PR TITLE
型定義ファイルの追加

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,4 @@
-export default class Weiwudi {
+export default class Weiwudi extends EventTarget {
   constructor(mapID: string, attrs: any);
 
   static registerSW(
@@ -23,7 +23,4 @@ export default class Weiwudi {
   public fetchAll(): Promise<void>;
   public remove(): Promise<void>;
   public cancel(): Promise<void>;
-
-  public addEventListener(type: string, handler: any): void;
-  public removeEventListener(type: string, handler: any): void;
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,29 @@
+export default class Weiwudi {
+  constructor(mapID: string, attrs: any);
+
+  static registerSW(
+    sw: string | URL,
+    swOptions: RegistrationOptions
+  ): Promise<ServiceWorkerRegistration>;
+  static swCheck(): Promise<boolean>;
+  static registerMap(mapID: string, options: any): Promise<Weiwudi>;
+  static retrieveMap(mapID: string): Promise<Weiwudi>;
+  static removeMap(mapID: string): Promise<void>;
+
+  public release(): void;
+  public checkAspect(): void;
+
+  public stats(): Promise<{
+    size?: number;
+    count?: number;
+    total?: number;
+    percent?: number;
+  }>;
+  public clean(): Promise<void>;
+  public fetchAll(): Promise<void>;
+  public remove(): Promise<void>;
+  public cancel(): Promise<void>;
+
+  public addEventListener(type: string, handler: any): void;
+  public removeEventListener(type: string, handler: any): void;
+}

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.4",
   "description": "Service worker for tile cache",
   "main": "src/weiwudi.js",
+  "types": "index.d.ts",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "build": "webpack --config webpack_config/webpack.config.build.js",


### PR DESCRIPTION
# 動機
本ライブラリをnpm installした際に各ユーザーが型定義ファイルを作成する必要をなくし, ライブラリ側で提供できるようにするため

## したこと
- [x] https://github.com/code4history/MaplatCore/blob/master/src/types/weiwudi.d.ts を参考に型定義ファイルを作成した
- [x] package.json に `types` フィールドを追加した